### PR TITLE
Bug 870093: removed 'shortname' from manifest

### DIFF
--- a/preload.py
+++ b/preload.py
@@ -186,7 +186,6 @@ def fetch_webapp(app_url, directory=None):
         manifest = json.loads(appzip.decode('utf-8-sig'))
 
     appname = get_directory_name(manifest['name'])
-    manifest["shortname"] = appname
     apppath = appname
     if directory is not None:
         apppath = os.path.join(directory, appname)


### PR DESCRIPTION
hi @fzzzy, I would like to remove 'shortname' from manifest but I found this added by you. could you explain why should we need this field? thanks!
